### PR TITLE
Launch the default editor to enter commit messages if `-m` is omitted

### DIFF
--- a/lib/turbine/commands/standard/commit.rb
+++ b/lib/turbine/commands/standard/commit.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'shellwords'
 
 Turbine::Application.extension do
   def commit
@@ -40,10 +41,13 @@ Turbine::Application.extension do
   #
   # Returns text saved to the temp file
   def message_from_editor
-    Tempfile.open('commit.txt') do |file|
-      editor = ENV['MM_EDITOR'] || ENV['EDITOR']
-      system([editor, file.path].join(' ')) if editor
+    editor = ENV['MM_EDITOR'] || ENV['EDITOR']
 
+    return unless editor
+
+    Tempfile.open('commit.txt') do |file|
+      editor_invocation = "#{editor} #{file.path}"
+      system(*Shellwords.split(editor_invocation))
       message = File.read(file.path)
     end
   end

--- a/mm.gemspec
+++ b/mm.gemspec
@@ -1,10 +1,10 @@
-MOMENTUM_VERSION = "0.2.0" 
+MOMENTUM_VERSION = "0.2.1" 
 
 Gem::Specification.new do |spec|
   spec.name = "mm"
   spec.version = MOMENTUM_VERSION
   spec.platform = Gem::Platform::RUBY
-  spec.summary = "A seecret"
+  spec.summary = "CLI for Madriska Momentum"
   spec.files =  Dir.glob("{examples,lib,spec,vendor,data,bin}/**/**/*") +
                       ["Rakefile"]
   spec.require_path = "lib"
@@ -12,10 +12,9 @@ Gem::Specification.new do |spec|
 
   spec.test_files = Dir[ "test/*_test.rb" ]
   spec.has_rdoc = true
-  spec.author = "Gregory Brown"
-  spec.email = "  gregory.t.brown@gmail.com"
-  spec.homepage = "http://pixelpowerhouse.com"
-  spec.description = <<END_DESC
-  Seeekrit
-END_DESC
+  spec.authors  = ["Gregory Brown", "Jordan Byron", "Brad Ediger"]
+  spec.email    = ["gregory.t.brown@gmail.com", "jordan.byron@gmail.com",
+                   "brad@bradedier.com"]
+  spec.homepage = "http://momentum.madriska.com"
+  spec.description = "CLI for Madriska Momentum"
 end


### PR DESCRIPTION
I suck at typing and my text editor does this cool thing called "spell check" which, as you might have guessed, checks your spelling. I'd like to easily take advantage of that like I do with `git commit`. So now you can just type `mm commit` and it will launch your editor, you can type your commit message, save it, and then momentum will read your message and send it along. Yay! :smile:

@bradediger / @brentvatne this implementation works great with `mvim -f`, but I'm not sure how well it will do with other editors. Since we are all rocking vim I just want to make sure it works for all of us before merging / deploying. Thanks!
